### PR TITLE
Change `message` strings in Exceptions

### DIFF
--- a/Person.Model.ValueObjects/CNPJ.cs
+++ b/Person.Model.ValueObjects/CNPJ.cs
@@ -34,7 +34,7 @@ namespace Person.Model.ValueObjects
 
             if (!Internal.IsValid(number))
                 throw new InvalidCastException(
-                    "A cadeia de caracteres informada não corresponde a um cnpj válido.");
+                    "A cadeia de caracteres informada não corresponde a um CNPJ válido.");
 
             Number = Internal.GetNumberFrom(number);
             CheckNumber = Internal.GetCheckNumberFrom(number);
@@ -49,7 +49,7 @@ namespace Person.Model.ValueObjects
         {
             if (cnpj == null)
                 throw new ArgumentNullException(nameof(cnpj),
-                    "Não é possível criar um cnpj a partir de um valor nulo.");
+                    "Não é possível criar um CNPJ a partir de um valor nulo.");
 
             if (IsOutOfRange(cnpj))
                 throw new ArgumentOutOfRangeException(

--- a/Person.Model.ValueObjects/CPF.cs
+++ b/Person.Model.ValueObjects/CPF.cs
@@ -31,7 +31,7 @@ namespace Person.Model.ValueObjects
 
             if (!Internal.IsValid(number))
                 throw new InvalidCastException(
-                    "A cadeia de caracteres informada não corresponde a um number válido.");
+                    "A cadeia de caracteres informada não corresponde a um CPF válido.");
 
             Number = Internal.GetNumberFrom(number);
             CheckNumber = Internal.GetCheckNumberFrom(number);
@@ -46,7 +46,7 @@ namespace Person.Model.ValueObjects
         {
             if (number == null)
                 throw new ArgumentNullException(nameof(number),
-                    "Não é possível criar um number a partir de um valor nulo.");
+                    "Não é possível criar um CPF a partir de um valor nulo.");
 
             if (IsOutOfRange(number))
                 throw new ArgumentOutOfRangeException(


### PR DESCRIPTION
In `CNPJ.cs` I've changed `InvalidCastException` and `ArgumentNullException` `message` strings to utilise CNPJ in upper case.

In `CPF.cs` I've changed `number` in `InvalidCastException` and `ArgumentNullException` `message` strings to CPF.