### PR TITLE
fix: version bump, PR review corrections and test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 ### Breaking changes
 
+#### All value objects
+- `[Serializable]` attribute removed. Code relying on `BinaryFormatter` or runtime serialization must be updated.
+
 #### CNPJ
 - Lowercase letters now throw `ArgumentOutOfRangeException` instead of being silently normalized.
 - `ToString()` uses substring-based formatting for all formats, including alphanumeric (`AB.123.456/0001-10`).
+- `IsNumeric(string)`, `IsFourteenLength(string)`, and `IsOutOfRange(string)` removed from the public API.
+- `GetNumberFrom(string)` and `GetCheckNumberFrom(string)` removed from the public API — use the `Number` and `CheckNumber` instance properties instead.
 
 #### CPF
 - `IsNumeric(string)`, `IsElevenLength(string)`, and `IsOutOfRange(string)` removed from the public API.
@@ -14,6 +19,11 @@
 
 #### LandLine / Mobile
 - `Raw` now always returns the canonical form `CountryCode + AreaCode + Number`, regardless of the input format. Code that relied on `Raw` returning the exact digits of the original input needs to be updated.
+- `GetOnlyNumbersFrom(string)` removed from the public API — digit extraction is now internal.
+- `ToString()` format corrected: now returns `+55 (51) 3635-2520` (area code in parentheses, hyphen in local number). The previous format was `+55 (51 3635 2520)`.
+
+#### JSON converters (LandLine / Mobile)
+- `LandLineConverter` and `MobileConverter` previously serialized a JSON object (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`). They now serialize as a plain JSON string (the canonical `Raw` value), consistent with `CardNumberConverter`. Existing payloads produced with the old converters are **not** compatible with this version.
 
 ---
 
@@ -59,12 +69,10 @@ CNPJ.IsValid("AB123456000110");      // true
 
 ### Bug fixes
 
-- **CardNumber.IsValid**: `NullReferenceException` when receiving `null` replaced by `ArgumentNullException`.
+- **CardNumber.IsValid**: now returns `false` for `null` input (consistent with `CNPJ.IsValid` and `CPF.IsValid`), replacing the previous `NullReferenceException`.
 - **LandLine / Mobile**: inconsistent equality between instances of the same number in different input formats (see `Raw` breaking change above).
 - **All value objects**: `\d` in regex patterns replaced with `[0-9]` — `\d` in .NET matches any Unicode decimal digit (Arabic-Indic, Devanagari, etc.), not just ASCII digits. This prevented nonsense input from being correctly rejected.
 - **All value objects**: `default(T).ToString()` now returns `string.Empty` instead of throwing `NullReferenceException`. The default struct state (uninitialized) is a known C# limitation; the null guard makes it safe for use in collections and nullable contexts.
-- **CardNumber.IsValid**: now returns `false` for `null` input (consistent with `CNPJ.IsValid` and `CPF.IsValid`) instead of throwing `ArgumentNullException`.
-- **JSON converters (LandLine / Mobile)**: `PhoneNumberFactory.Write` previously serialized a JSON object (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`); deserialization read only the `"Raw"` field, making the serialization asymmetric and brittle. Both converters now serialize as a plain JSON string (the canonical `Raw` value), consistent with `CardNumberConverter`. **This is a breaking change for any existing serialized JSON payload using these converters.**
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [10.0.0] — 2026-06-02
+## [10.0.0-preview.1] — 2026-06-02
 
 ### Breaking changes
 

--- a/Person.Model.ValueObjects/CNPJ.cs
+++ b/Person.Model.ValueObjects/CNPJ.cs
@@ -13,10 +13,12 @@ namespace Person.Model.ValueObjects
     /// for casing before constructing the value.
     /// </para>
     /// <para>
-    /// <b>v2 breaking changes:</b>
+    /// <b>v10 breaking changes:</b>
     /// <list type="bullet">
     ///   <item><description><c>ToString()</c> uses alphanumeric mask for all formats (<c>AB.123.456/0001-00</c>).</description></item>
     ///   <item><description>Lowercase letters throw <c>ArgumentOutOfRangeException</c> instead of being silently uppercased.</description></item>
+    ///   <item><description>Internal helper methods (<c>IsNumeric</c>, <c>IsFourteenLength</c>, <c>IsOutOfRange</c>, <c>GetNumberFrom</c>, <c>GetCheckNumberFrom</c>) removed from the public API.</description></item>
+    ///   <item><description><c>[Serializable]</c> attribute removed.</description></item>
     /// </list>
     /// </para>
     /// <see href="https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf"/>

--- a/Person.Model.ValueObjects/Person.Model.ValueObjects.csproj
+++ b/Person.Model.ValueObjects/Person.Model.ValueObjects.csproj
@@ -6,11 +6,11 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>Rafael Mac Menz</Authors>
 		<Company>McMenz IT</Company>
-		<Description>A .NET 10.0 collection with value objects that intend to model some Brazilian's Person domain properties</Description>
+		<Description>A .NET 10.0 collection with value objects that model Brazilian person domain properties</Description>
 		<NeutralLanguage>pt-BR</NeutralLanguage>
 		<RepositoryUrl>https://github.com/m4cm3nz/Person.Model.ValueObjects</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<PackageTags>value-object cnpj cpf mobile landline person</PackageTags>
+		<PackageTags>value-object cnpj cpf mobile landline cardnumber luhn brazil brazilian person</PackageTags>
 		<PackageReleaseNotes>See CHANGELOG.md</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -22,6 +22,7 @@
 
 	<ItemGroup>
 		<None Include="..\readme.md" Pack="true" PackagePath="\" />
+		<None Include="..\CHANGELOG.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 </Project>

--- a/Person.Model.ValueObjects/Person.Model.ValueObjects.csproj
+++ b/Person.Model.ValueObjects/Person.Model.ValueObjects.csproj
@@ -16,7 +16,7 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageProjectUrl>https://github.com/m4cm3nz/Person.Model.ValueObjects</PackageProjectUrl>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<Version>10.0.0</Version>
+		<Version>10.0.0-preview.1</Version>
 		<AssemblyVersion>10.0.0.0</AssemblyVersion>
 	</PropertyGroup>
 

--- a/Person.Model.ValueObjectsTests/CardNumberTests.cs
+++ b/Person.Model.ValueObjectsTests/CardNumberTests.cs
@@ -137,7 +137,9 @@ namespace Person.Model.ValueObjects.Tests
         // ------------------------------------------------------------------ //
 
         [Test]
-        [TestCase("4929622041254286", "**** **** **** 4286")]
+        [TestCase("4929622041254286", "**** **** **** 4286")]  // Visa 16
+        [TestCase("38538228319872",   "**** **** **98 72")]    // Diners 14
+        [TestCase("371449635398431",  "**** **** ***8 431")]   // AmEx 15
         public void ToStringFormatsCorrectlyTest(string number, string expected)
         {
             CardNumber cardNumber = number;
@@ -146,12 +148,20 @@ namespace Person.Model.ValueObjects.Tests
         }
 
         [Test]
-        [TestCase("4929622041254286", "4929 6220 4125 4286")]
+        [TestCase("4929622041254286", "4929 6220 4125 4286")]  // Visa 16
+        [TestCase("38538228319872",   "3853 8228 3198 72")]    // Diners 14
+        [TestCase("371449635398431",  "3714 4963 5398 431")]   // AmEx 15
         public void ToFormattedReturnsFullNumberTest(string number, string expected)
         {
             CardNumber cardNumber = number;
 
             Assert.That(cardNumber.ToFormatted(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void DefaultToStringReturnsEmptyTest()
+        {
+            Assert.That(default(CardNumber).ToString(), Is.EqualTo(string.Empty));
         }
 
         // ------------------------------------------------------------------ //

--- a/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
+++ b/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using Person.Model.ValueObjects;
 using Person.Model.ValueObjects.Json;
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -34,6 +35,71 @@ namespace Person.Model.ValueObjects.Tests
 
             Assert.That(newDummy.Mobile, Is.EqualTo(dummyObject.Mobile));
             Assert.That(newDummy.LandLine, Is.EqualTo(dummyObject.LandLine));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Payload format — converters must serialise as plain JSON string     //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void MobileConverterSerializesAsPlainStringTest()
+        {
+            Mobile mobile = "51985680052";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new MobileConverter());
+
+            var json = JsonSerializer.Serialize(mobile, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo(mobile.Raw));
+        }
+
+        [Test]
+        public void LandLineConverterSerializesAsPlainStringTest()
+        {
+            LandLine? landLine = "5136350102";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new LandLineConverter());
+
+            var json = JsonSerializer.Serialize(landLine, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo(landLine.Value.Raw));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Null token handling                                                 //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void MobileConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new MobileConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Mobile>("null", options));
+        }
+
+        [Test]
+        public void CardNumberConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CardNumberConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CardNumber>("null", options));
+        }
+
+        [Test]
+        public void LandLineConverterReturnsNullOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new LandLineConverter());
+
+            var result = JsonSerializer.Deserialize<LandLine?>("null", options);
+
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/Person.Model.ValueObjectsTests/LandLineTests.cs
+++ b/Person.Model.ValueObjectsTests/LandLineTests.cs
@@ -125,6 +125,52 @@ namespace Person.Model.ValueObjects.Tests
         }
 
         // ------------------------------------------------------------------ //
+        // Equality                                                           //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void EqualityBetweenEquivalentFormatsTest()
+        {
+            LandLine a = new("5136352520");
+            LandLine b = new("+55 (51) 3635-2520");
+
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a == b, Is.True);
+            Assert.That(a != b, Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void InequalityBetweenDifferentLandLinesTest()
+        {
+            LandLine a = new("5136352520");
+            LandLine b = new("5136350020");
+
+            Assert.That(a != b, Is.True);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Default struct                                                      //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void DefaultToStringReturnsEmptyTest()
+        {
+            Assert.That(default(LandLine).ToString(), Is.EqualTo(string.Empty));
+        }
+
+        // ------------------------------------------------------------------ //
+        // DoS — max input length                                              //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void InputExceedingMaxLengthIsRejectedTest()
+        {
+            var oversized = new string('5', 31);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new LandLine(oversized));
+        }
+
+        // ------------------------------------------------------------------ //
         // Nullable                                                            //
         // ------------------------------------------------------------------ //
 

--- a/Person.Model.ValueObjectsTests/MobileTests.cs
+++ b/Person.Model.ValueObjectsTests/MobileTests.cs
@@ -128,5 +128,51 @@ namespace Person.Model.ValueObjects.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new Mobile(phone));
         }
+
+        // ------------------------------------------------------------------ //
+        // Equality                                                            //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void EqualityBetweenEquivalentFormatsTest()
+        {
+            Mobile a = new("51936351064");
+            Mobile b = new("+55 (51) 93635-1064");
+
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a == b, Is.True);
+            Assert.That(a != b, Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void InequalityBetweenDifferentMobilesTest()
+        {
+            Mobile a = new("51936351064");
+            Mobile b = new("51987654321");
+
+            Assert.That(a != b, Is.True);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Default struct                                                      //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void DefaultToStringReturnsEmptyTest()
+        {
+            Assert.That(default(Mobile).ToString(), Is.EqualTo(string.Empty));
+        }
+
+        // ------------------------------------------------------------------ //
+        // DoS — max input length                                              //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void InputExceedingMaxLengthIsRejectedTest()
+        {
+            var oversized = new string('5', 31);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Mobile(oversized));
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ numeric format and the **new alphanumeric format** introduced by
 Formatting characters (`.` `/` `-`) are stripped automatically on construction.
 Lowercase letters are **rejected** — the caller is responsible for casing.
 
-> **v2 breaking changes**
+> **v10 breaking changes**
 > - `ToString()` now uses alphanumeric mask for all formats (`AB.123.456/0001-10`).
 > - Lowercase letters throw `ArgumentOutOfRangeException` instead of being silently uppercased.
+> - Internal helper methods (`IsNumeric`, `IsFourteenLength`, `IsOutOfRange`, `GetNumberFrom`, `GetCheckNumberFrom`) removed from the public API.
 
 ### Creation
 
@@ -156,7 +157,7 @@ First digit of the local number must be between 2 and 5.
 Accepted patterns (DDI optional, DDD required, punctuation and spaces flexible):
 
 ```
-^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?([2-5]\d{3}[- ]?\d{4})$
+^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?([2-5][0-9]{3}[- ]?[0-9]{4})$
 ```
 
 ### Creation
@@ -202,7 +203,7 @@ First digit of the local number must be 9 (total of 9 digits).
 Accepted patterns (DDI optional, DDD required, punctuation and spaces flexible):
 
 ```
-^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?(9\d{4}[- ]?\d{4})$
+^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?(9[0-9]{4}[- ]?[0-9]{4})$
 ```
 
 ### Creation
@@ -254,7 +255,7 @@ CardNumber card = "4929622041254286"; // implicit operator
 
 | Exception | Condition |
 |---|---|
-| `ArgumentNullException` | `null` passed to constructor or `IsValid` |
+| `ArgumentNullException` | `null` passed to constructor |
 | `ArgumentException` | invalid length or Luhn check fails |
 
 ### Properties
@@ -287,6 +288,11 @@ CardNumber.IsValid(null);              // false
 
 Converters for `System.Text.Json` are available in the `Person.Model.ValueObjects.Json` namespace
 for `LandLine`, `Mobile`, and `CardNumber`.
+
+> **v10 breaking change** — `LandLineConverter` and `MobileConverter` previously serialized a JSON
+> object (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`). They now serialize as
+> a plain JSON string (the canonical `Raw` value), consistent with `CardNumberConverter`. Existing
+> payloads produced with the old converters are **not** compatible with this version.
 
 ```csharp
 // via JsonSerializerOptions


### PR DESCRIPTION
## Summary

Commits that missed the original PR merge:

- **Version**: bump to `10.0.0-preview.1` (pre-release due to v10 breaking changes)
- **CHANGELOG**: add missing breaking changes (`[Serializable]` removal, CNPJ/LandLine/Mobile public API removals, `ToString()` format change, JSON converter payload format); consolidate conflicting `CardNumber.IsValid(null)` entries
- **README**: regex `\d` corrected to `[0-9]` in LandLine and Mobile sections; CardNumber exception table fixed (`IsValid(null)` returns `false`, not throws); v2 updated to v10 in CNPJ breaking changes; JSON converters section documents the payload format breaking change
- **CNPJ.cs**: XML doc updated to v10; removed public methods listed in breaking changes
- **csproj**: Description fixed; `PackageTags` expanded (`cardnumber`, `luhn`, `brazil`, `brazilian`); `CHANGELOG.md` now packed into the `.nupkg`
- **Tests**: 225 → 243 — LandLine/Mobile equality across input formats; `default(T).ToString()`; MaxInputLength (DoS cap); `ToString`/`ToFormatted` for Diners (14-digit) and AmEx (15-digit); JSON converters serialise as plain string; null token handling for all converters

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 243/243 passing
- [x] `CardNumber.IsValid(null)` returns `false`
- [x] JSON payload is a plain string (not an object) for `LandLine` and `Mobile`
- [x] `LandLine` / `Mobile` equality holds across all accepted input formats
- [x] Diners (14-digit) and AmEx (15-digit) masking correct

Generated with Claude Code