### PR TITLE
feat: .NET 10 upgrade, alphanumeric CNPJ, JSON converters for CPF/CNPJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,34 @@
 - `GetOnlyNumbersFrom(string)` removed from the public API — digit extraction is now internal.
 - `ToString()` format corrected: now returns `+55 (51) 3635-2520` (area code in parentheses, hyphen in local number). The previous format was `+55 (51 3635 2520)`.
 
-#### JSON converters (LandLine / Mobile)
+#### JSON converters
 - `LandLineConverter` and `MobileConverter` previously serialized a JSON object (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`). They now serialize as a plain JSON string (the canonical `Raw` value), consistent with `CardNumberConverter`. Existing payloads produced with the old converters are **not** compatible with this version.
+- `LandLineConverter` changed from `JsonConverter<LandLine?>` to `JsonConverter<LandLine>`. Property-level `[JsonConverter(typeof(LandLineConverter))]` annotations remain valid but are no longer required.
+
+#### CardNumber
+- `Number` property removed from the public API — the raw PAN is accessible via the implicit `string` cast (`(string)card`). This prevents accidental exposure in logs, default serialization, and reflection-based tooling.
 
 ---
 
 ### New features
+
+#### JSON converters — all five value objects
+- `CpfConverter` and `CnpjConverter` added to the `Person.Model.ValueObjects.Json` namespace.
+- All five value objects (`CPF`, `CNPJ`, `Mobile`, `LandLine`, `CardNumber`) now carry a `[JsonConverter]` attribute on the struct itself. `System.Text.Json` discovers the correct converter automatically — no `[JsonConverter]` annotation on properties and no `options.Converters.Add()` call is needed.
+- Null handling: JSON `null` for a nullable property (`T?`) returns `null`; JSON `null` for a non-nullable property throws `JsonException`; non-string tokens (numbers, booleans, objects) throw `JsonException`.
+
+```csharp
+public class Subscriber
+{
+    public CPF       Cpf      { get; set; }
+    public CNPJ?     Cnpj     { get; set; }
+    public Mobile    Mobile   { get; set; }
+    public LandLine? LandLine { get; set; }
+}
+
+var json   = JsonSerializer.Serialize(subscriber);            // works out of the box
+var result = JsonSerializer.Deserialize<Subscriber>(json);    // works out of the box
+```
 
 #### CNPJ — alphanumeric format
 Support for the new alphanumeric CNPJ format from Receita Federal (IN RFB nº 2.229/2024), effective July 2026.

--- a/Person.Model.ValueObjects/CNPJ.cs
+++ b/Person.Model.ValueObjects/CNPJ.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text.Json.Serialization;
+using Person.Model.ValueObjects.Json;
 
 namespace Person.Model.ValueObjects
 {
@@ -23,6 +25,7 @@ namespace Person.Model.ValueObjects
     /// </para>
     /// <see href="https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf"/>
     /// </summary>
+    [JsonConverter(typeof(CnpjConverter))]
     public readonly struct CNPJ : IEquatable<CNPJ>
     {
         private const int CheckNumberLength = 2;

--- a/Person.Model.ValueObjects/CPF.cs
+++ b/Person.Model.ValueObjects/CPF.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text.Json.Serialization;
+using Person.Model.ValueObjects.Json;
 
 namespace Person.Model.ValueObjects
 {
@@ -8,6 +10,7 @@ namespace Person.Model.ValueObjects
     /// Format: 9-digit root + 2 check digits (11 numeric digits total).
     /// Accepts input with or without the formatting mask (<c>123.456.789-09</c>).
     /// </summary>
+    [JsonConverter(typeof(CpfConverter))]
     public readonly struct CPF : IEquatable<CPF>
     {
         private const int CheckNumberLength = 2;

--- a/Person.Model.ValueObjects/CardNumber.cs
+++ b/Person.Model.ValueObjects/CardNumber.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text;
+using System.Text.Json.Serialization;
+using Person.Model.ValueObjects.Json;
 
 namespace Person.Model.ValueObjects
 {
@@ -7,6 +9,7 @@ namespace Person.Model.ValueObjects
     /// Immutable value object representing a valid payment card number.
     /// Validates the number via the Luhn algorithm (mod 10). Accepts cards with 13 to 19 digits.
     /// </summary>
+    [JsonConverter(typeof(CardNumberConverter))]
     public readonly struct CardNumber : IEquatable<CardNumber>
     {
         private readonly string _number;

--- a/Person.Model.ValueObjects/CardNumber.cs
+++ b/Person.Model.ValueObjects/CardNumber.cs
@@ -11,9 +11,6 @@ namespace Person.Model.ValueObjects
     {
         private readonly string _number;
 
-        /// <summary>The card number without formatting.</summary>
-        public string Number => _number;
-
         /// <summary>
         /// Constructs a CardNumber from a digit string.
         /// </summary>

--- a/Person.Model.ValueObjects/Json/CardNumberConverter.cs
+++ b/Person.Model.ValueObjects/Json/CardNumberConverter.cs
@@ -6,14 +6,23 @@ namespace Person.Model.ValueObjects.Json
 {
     public class CardNumberConverter : JsonConverter<CardNumber>
     {
+        public override bool HandleNull => true;
+
         public override CardNumber Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)
                 throw new JsonException("CardNumber cannot be null. Use CardNumber? for nullable.");
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for CardNumber, got {reader.TokenType}.");
             return new(reader.GetString()!);
         }
 
-        public override void Write(Utf8JsonWriter writer, CardNumber value, JsonSerializerOptions options) =>
-            writer.WriteStringValue(value);
+        public override void Write(Utf8JsonWriter writer, CardNumber value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) CardNumber.");
+            writer.WriteStringValue(raw);
+        }
     }
 }

--- a/Person.Model.ValueObjects/Json/CnpjConverter.cs
+++ b/Person.Model.ValueObjects/Json/CnpjConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Person.Model.ValueObjects.Json
+{
+    public class CnpjConverter : JsonConverter<CNPJ>
+    {
+        public override CNPJ Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                throw new JsonException("CNPJ cannot be null. Use CNPJ? for nullable.");
+            return new(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, CNPJ value, JsonSerializerOptions options) =>
+            writer.WriteStringValue((string)value);
+    }
+}

--- a/Person.Model.ValueObjects/Json/CnpjConverter.cs
+++ b/Person.Model.ValueObjects/Json/CnpjConverter.cs
@@ -6,14 +6,23 @@ namespace Person.Model.ValueObjects.Json
 {
     public class CnpjConverter : JsonConverter<CNPJ>
     {
+        public override bool HandleNull => true;
+
         public override CNPJ Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)
                 throw new JsonException("CNPJ cannot be null. Use CNPJ? for nullable.");
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for CNPJ, got {reader.TokenType}.");
             return new(reader.GetString()!);
         }
 
-        public override void Write(Utf8JsonWriter writer, CNPJ value, JsonSerializerOptions options) =>
-            writer.WriteStringValue((string)value);
+        public override void Write(Utf8JsonWriter writer, CNPJ value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) CNPJ.");
+            writer.WriteStringValue(raw);
+        }
     }
 }

--- a/Person.Model.ValueObjects/Json/CpfConverter.cs
+++ b/Person.Model.ValueObjects/Json/CpfConverter.cs
@@ -6,14 +6,23 @@ namespace Person.Model.ValueObjects.Json
 {
     public class CpfConverter : JsonConverter<CPF>
     {
+        public override bool HandleNull => true;
+
         public override CPF Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)
                 throw new JsonException("CPF cannot be null. Use CPF? for nullable.");
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for CPF, got {reader.TokenType}.");
             return new(reader.GetString()!);
         }
 
-        public override void Write(Utf8JsonWriter writer, CPF value, JsonSerializerOptions options) =>
-            writer.WriteStringValue((string)value);
+        public override void Write(Utf8JsonWriter writer, CPF value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) CPF.");
+            writer.WriteStringValue(raw);
+        }
     }
 }

--- a/Person.Model.ValueObjects/Json/CpfConverter.cs
+++ b/Person.Model.ValueObjects/Json/CpfConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Person.Model.ValueObjects.Json
+{
+    public class CpfConverter : JsonConverter<CPF>
+    {
+        public override CPF Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                throw new JsonException("CPF cannot be null. Use CPF? for nullable.");
+            return new(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, CPF value, JsonSerializerOptions options) =>
+            writer.WriteStringValue((string)value);
+    }
+}

--- a/Person.Model.ValueObjects/Json/LandLineConverter.cs
+++ b/Person.Model.ValueObjects/Json/LandLineConverter.cs
@@ -4,17 +4,23 @@ using System.Text.Json.Serialization;
 
 namespace Person.Model.ValueObjects.Json
 {
-    public class LandLineConverter : JsonConverter<LandLine?>
+    // HandleNull defaults to false: STJ returns null for LandLine? without calling Read,
+    // and skips Write for null LandLine? values — no null-handling needed here.
+    public class LandLineConverter : JsonConverter<LandLine>
     {
-        public override LandLine? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-            PhoneNumberFactory.CreateLandLine(ref reader);
-
-        public override void Write(Utf8JsonWriter writer, LandLine? value, JsonSerializerOptions options)
+        public override LandLine Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (value is null)
-                writer.WriteNullValue();
-            else
-                PhoneNumberFactory.WriteString(writer, value.Value.Raw);
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for LandLine, got {reader.TokenType}.");
+            return new(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, LandLine value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) LandLine.");
+            writer.WriteStringValue(raw);
         }
     }
 }

--- a/Person.Model.ValueObjects/Json/MobileConverter.cs
+++ b/Person.Model.ValueObjects/Json/MobileConverter.cs
@@ -6,14 +6,23 @@ namespace Person.Model.ValueObjects.Json
 {
     public class MobileConverter : JsonConverter<Mobile>
     {
+        public override bool HandleNull => true;
+
         public override Mobile Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)
                 throw new JsonException("Mobile cannot be null. Use Mobile? for nullable.");
-            return PhoneNumberFactory.CreateMobile(ref reader);
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for Mobile, got {reader.TokenType}.");
+            return new(reader.GetString()!);
         }
 
-        public override void Write(Utf8JsonWriter writer, Mobile value, JsonSerializerOptions options) =>
-            PhoneNumberFactory.WriteString(writer, value.Raw);
+        public override void Write(Utf8JsonWriter writer, Mobile value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) Mobile.");
+            writer.WriteStringValue(raw);
+        }
     }
 }

--- a/Person.Model.ValueObjects/LandLine.cs
+++ b/Person.Model.ValueObjects/LandLine.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Person.Model.ValueObjects.Json;
 
 namespace Person.Model.ValueObjects
 {
@@ -12,6 +14,7 @@ namespace Person.Model.ValueObjects
     /// regardless of the input format.
     /// </para>
     /// </summary>
+    [JsonConverter(typeof(LandLineConverter))]
     public readonly struct LandLine : IPhoneNumber, IEquatable<LandLine>
     {
         private const int MaxInputLength = 30;

--- a/Person.Model.ValueObjects/Mobile.cs
+++ b/Person.Model.ValueObjects/Mobile.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Person.Model.ValueObjects.Json;
 
 namespace Person.Model.ValueObjects
 {
@@ -12,6 +14,7 @@ namespace Person.Model.ValueObjects
     /// regardless of the input format.
     /// </para>
     /// </summary>
+    [JsonConverter(typeof(MobileConverter))]
     public readonly struct Mobile : IPhoneNumber, IEquatable<Mobile>
     {
         private const int MaxInputLength = 30;

--- a/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
+++ b/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
@@ -104,6 +104,15 @@ namespace Person.Model.ValueObjects.Tests
         }
 
         [Test]
+        public void CardNumberConverterThrowsOnNonStringTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CardNumberConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CardNumber>("4111111111111111", options));
+        }
+
+        [Test]
         public void LandLineConverterDeserializesFromPlainStringTest()
         {
             LandLine expected = "5136350102";
@@ -244,6 +253,26 @@ namespace Person.Model.ValueObjects.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CPF>("null", options));
         }
 
+        [Test]
+        public void CpfConverterThrowsOnNonStringTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CpfConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CPF>("52998224725", options));
+        }
+
+        [Test]
+        public void CpfConverterThrowsOnPropertyLevelNullTest()
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            options.Converters.Add(new CpfConverter());
+            options.Converters.Add(new CnpjConverter());
+
+            Assert.Throws<JsonException>(() =>
+                JsonSerializer.Deserialize<DummySubscriber>("{\"Name\":\"x\",\"Cpf\":null,\"Cnpj\":\"11222333000181\"}", options));
+        }
+
         // ------------------------------------------------------------------ //
         // CNPJ converter                                                      //
         // ------------------------------------------------------------------ //
@@ -280,6 +309,15 @@ namespace Person.Model.ValueObjects.Tests
             options.Converters.Add(new CnpjConverter());
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNPJ>("null", options));
+        }
+
+        [Test]
+        public void CnpjConverterThrowsOnNonStringTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnpjConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNPJ>("11222333000181", options));
         }
     }
 }

--- a/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
+++ b/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
@@ -16,6 +16,15 @@ namespace Person.Model.ValueObjects.Tests
         public LandLine? LandLine { get; set; }
     }
 
+    internal class DummySubscriber
+    {
+        public string Name { get; set; }
+        [JsonConverter(typeof(CpfConverter))]
+        public CPF Cpf { get; set; }
+        [JsonConverter(typeof(CnpjConverter))]
+        public CNPJ Cnpj { get; set; }
+    }
+
     [TestFixture]
     internal class JsonDeserializationTests
     {
@@ -74,12 +83,86 @@ namespace Person.Model.ValueObjects.Tests
         // ------------------------------------------------------------------ //
 
         [Test]
+        public void MobileConverterDeserializesFromPlainStringTest()
+        {
+            Mobile expected = "51985680052";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new MobileConverter());
+
+            var result = JsonSerializer.Deserialize<Mobile>($"\"{expected.Raw}\"", options);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
         public void MobileConverterThrowsOnNullTokenTest()
         {
             var options = new JsonSerializerOptions();
             options.Converters.Add(new MobileConverter());
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Mobile>("null", options));
+        }
+
+        [Test]
+        public void LandLineConverterDeserializesFromPlainStringTest()
+        {
+            LandLine expected = "5136350102";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new LandLineConverter());
+
+            var result = JsonSerializer.Deserialize<LandLine?>($"\"{expected.Raw}\"", options);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void LandLineConverterSerializesNullAsJsonNullTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new LandLineConverter());
+
+            var json = JsonSerializer.Serialize<LandLine?>(null, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Null));
+        }
+
+        [Test]
+        public void CardNumberConverterSerializesAsPlainStringTest()
+        {
+            CardNumber cardNumber = new("4111111111111111");
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CardNumberConverter());
+
+            var json = JsonSerializer.Serialize(cardNumber, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo("4111111111111111"));
+        }
+
+        [Test]
+        public void CardNumberConverterDeserializesFromPlainStringTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CardNumberConverter());
+
+            var result = JsonSerializer.Deserialize<CardNumber>("\"4111111111111111\"", options);
+
+            Assert.That(result, Is.EqualTo(new CardNumber("4111111111111111")));
+        }
+
+        [Test]
+        public void CardNumberConverterRoundTripTest()
+        {
+            CardNumber cardNumber = new("4111111111111111");
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CardNumberConverter());
+
+            var json = JsonSerializer.Serialize(cardNumber, options);
+            var result = JsonSerializer.Deserialize<CardNumber>(json, options);
+
+            Assert.That(result, Is.EqualTo(cardNumber));
         }
 
         [Test]
@@ -100,6 +183,103 @@ namespace Person.Model.ValueObjects.Tests
             var result = JsonSerializer.Deserialize<LandLine?>("null", options);
 
             Assert.That(result, Is.Null);
+        }
+
+        // ------------------------------------------------------------------ //
+        // CPF converter                                                       //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void CpfConverterSerializesAsPlainStringTest()
+        {
+            CPF cpf = "52998224725";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CpfConverter());
+
+            var json = JsonSerializer.Serialize(cpf, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo("52998224725"));
+        }
+
+        [Test]
+        public void CpfConverterRoundTripWithCaseInsensitiveOptionsTest()
+        {
+            var subscriber = new DummySubscriber
+            {
+                Name = "Rafael",
+                Cpf = "52998224725",
+                Cnpj = "11222333000181",
+            };
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            options.Converters.Add(new CpfConverter());
+            options.Converters.Add(new CnpjConverter());
+
+            var json = JsonSerializer.Serialize(subscriber, options);
+            var result = JsonSerializer.Deserialize<DummySubscriber>(json, options);
+
+            Assert.That(result.Cpf, Is.EqualTo(subscriber.Cpf));
+            Assert.That(result.Cnpj, Is.EqualTo(subscriber.Cnpj));
+        }
+
+        [Test]
+        public void CpfConverterDeserializesFromPlainStringTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CpfConverter());
+
+            var result = JsonSerializer.Deserialize<CPF>("\"52998224725\"", options);
+
+            Assert.That(result, Is.EqualTo(new CPF("52998224725")));
+        }
+
+        [Test]
+        public void CpfConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CpfConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CPF>("null", options));
+        }
+
+        // ------------------------------------------------------------------ //
+        // CNPJ converter                                                      //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void CnpjConverterSerializesAsPlainStringTest()
+        {
+            CNPJ cnpj = "11222333000181";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnpjConverter());
+
+            var json = JsonSerializer.Serialize(cnpj, options);
+            var doc = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo("11222333000181"));
+        }
+
+        [Test]
+        public void CnpjConverterDeserializesFromPlainStringTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnpjConverter());
+
+            var result = JsonSerializer.Deserialize<CNPJ>("\"11222333000181\"", options);
+
+            Assert.That(result, Is.EqualTo(new CNPJ("11222333000181")));
+        }
+
+        [Test]
+        public void CnpjConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnpjConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNPJ>("null", options));
         }
     }
 }

--- a/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
+++ b/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
@@ -357,5 +357,89 @@ namespace Person.Model.ValueObjects.Tests
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNPJ>("11222333000181", options));
         }
+
+        // ------------------------------------------------------------------ //
+        // Nullable variants — T? must round-trip and accept null             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void NullableCpfDeserializesNullTokenAsNullTest()
+        {
+            var result = JsonSerializer.Deserialize<CPF?>("null");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void NullableCpfRoundTripTest()
+        {
+            CPF? value = new CPF("52998224725");
+            var json = JsonSerializer.Serialize(value);
+            var result = JsonSerializer.Deserialize<CPF?>(json);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void NullableCnpjDeserializesNullTokenAsNullTest()
+        {
+            var result = JsonSerializer.Deserialize<CNPJ?>("null");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void NullableCnpjRoundTripTest()
+        {
+            CNPJ? value = new CNPJ("11222333000181");
+            var json = JsonSerializer.Serialize(value);
+            var result = JsonSerializer.Deserialize<CNPJ?>(json);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void NullableMobileDeserializesNullTokenAsNullTest()
+        {
+            var result = JsonSerializer.Deserialize<Mobile?>("null");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void NullableMobileRoundTripTest()
+        {
+            Mobile? value = new Mobile("51985680052");
+            var json = JsonSerializer.Serialize(value);
+            var result = JsonSerializer.Deserialize<Mobile?>(json);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void NullableCardNumberDeserializesNullTokenAsNullTest()
+        {
+            var result = JsonSerializer.Deserialize<CardNumber?>("null");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void NullableCardNumberRoundTripTest()
+        {
+            CardNumber? value = new CardNumber("4111111111111111");
+            var json = JsonSerializer.Serialize(value);
+            var result = JsonSerializer.Deserialize<CardNumber?>(json);
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void NullableLandLineDeserializesNullTokenAsNullTest()
+        {
+            var result = JsonSerializer.Deserialize<LandLine?>("null");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void NullableLandLineRoundTripTest()
+        {
+            LandLine? value = new LandLine("5136350102");
+            var json = JsonSerializer.Serialize(value);
+            var result = JsonSerializer.Deserialize<LandLine?>(json);
+            Assert.That(result, Is.EqualTo(value));
+        }
     }
 }

--- a/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
+++ b/Person.Model.ValueObjectsTests/JsonDeserializationTests.cs
@@ -25,9 +25,47 @@ namespace Person.Model.ValueObjects.Tests
         public CNPJ Cnpj { get; set; }
     }
 
+    // No [JsonConverter] attributes — relies entirely on the struct-level [JsonConverter] attribute.
+    internal class DummyWithAutoConverters
+    {
+        public string Name { get; set; }
+        public CPF Cpf { get; set; }
+        public CNPJ Cnpj { get; set; }
+        public Mobile Mobile { get; set; }
+        public LandLine? LandLine { get; set; }
+        public CardNumber CardNumber { get; set; }
+    }
+
     [TestFixture]
     internal class JsonDeserializationTests
     {
+        // ------------------------------------------------------------------ //
+        // Struct-level [JsonConverter] — no property annotation needed       //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void AllValueObjectsRoundTripWithoutPropertyAnnotationsTest()
+        {
+            var original = new DummyWithAutoConverters
+            {
+                Name = "Rafael",
+                Cpf = "52998224725",
+                Cnpj = "11222333000181",
+                Mobile = "51985680052",
+                LandLine = "5136350102",
+                CardNumber = new CardNumber("4111111111111111"),
+            };
+
+            var json = JsonSerializer.Serialize(original);
+            var result = JsonSerializer.Deserialize<DummyWithAutoConverters>(json);
+
+            Assert.That(result.Cpf, Is.EqualTo(original.Cpf));
+            Assert.That(result.Cnpj, Is.EqualTo(original.Cnpj));
+            Assert.That(result.Mobile, Is.EqualTo(original.Mobile));
+            Assert.That(result.LandLine, Is.EqualTo(original.LandLine));
+            Assert.That(result.CardNumber, Is.EqualTo(original.CardNumber));
+        }
+
         [Test]
         public void ShouldBeAbleToDeserializeMobileAndLandlineUsingTextJson()
         {

--- a/README.md
+++ b/README.md
@@ -267,8 +267,7 @@ formatted number when the unmasked value is required.
 ```csharp
 CardNumber card = "4929622041254286";
 
-Console.WriteLine((string)card);       // 4929622041254286
-Console.WriteLine(card.Number);        // 4929622041254286
+Console.WriteLine((string)card);       // 4929622041254286  (raw digits)
 Console.WriteLine(card.ToString());    // **** **** **** 4286  (masked — safe for logs)
 Console.WriteLine(card.ToFormatted()); // 4929 6220 4125 4286
 ```

--- a/README.md
+++ b/README.md
@@ -285,29 +285,60 @@ CardNumber.IsValid(null);              // false
 
 ## JSON converters
 
-Converters for `System.Text.Json` are available in the `Person.Model.ValueObjects.Json` namespace
-for `LandLine`, `Mobile`, and `CardNumber`.
+All five value objects carry a `[JsonConverter]` attribute on the struct itself.
+`System.Text.Json` discovers the converter automatically — no property annotation
+or `options.Converters.Add()` call is needed.
 
-> **v10 breaking change** — `LandLineConverter` and `MobileConverter` previously serialized a JSON
-> object (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`). They now serialize as
-> a plain JSON string (the canonical `Raw` value), consistent with `CardNumberConverter`. Existing
-> payloads produced with the old converters are **not** compatible with this version.
+| Type | Converter | Wire format |
+|---|---|---|
+| `CPF` | `CpfConverter` | `"52998224725"` |
+| `CNPJ` | `CnpjConverter` | `"11222333000181"` |
+| `Mobile` | `MobileConverter` | `"5551985680052"` |
+| `LandLine` | `LandLineConverter` | `"555136352520"` |
+| `CardNumber` | `CardNumberConverter` | `"4929622041254286"` |
+
+All converters serialize as a **plain JSON string** — the canonical digit form, never the
+formatted mask (e.g. `123.456.789-09`).
 
 ```csharp
-// via JsonSerializerOptions
-var options = new JsonSerializerOptions();
-options.Converters.Add(new CardNumberConverter());
-
-// via attribute
-public class Payment
+public class Subscriber
 {
-    [JsonConverter(typeof(CardNumberConverter))]
-    public CardNumber? CardNumber { get; set; }
-
-    [JsonConverter(typeof(MobileConverter))]
-    public Mobile Mobile { get; set; }
-
-    [JsonConverter(typeof(LandLineConverter))]
+    public CPF      Cpf      { get; set; }
+    public CNPJ?    Cnpj     { get; set; }
+    public Mobile   Mobile   { get; set; }
     public LandLine? LandLine { get; set; }
+    public CardNumber CardNumber { get; set; }
 }
+
+// just works — no [JsonConverter] annotations required
+var json   = JsonSerializer.Serialize(subscriber);
+var result = JsonSerializer.Deserialize<Subscriber>(json);
 ```
+
+### Null handling
+
+| Scenario | Behavior |
+|---|---|
+| JSON `null` for nullable property (`T?`) | returns `null` |
+| JSON `null` for non-nullable property (`T`) | `JsonException` |
+| Non-string token (number, boolean, object) | `JsonException` |
+| Invalid value (bad format, wrong check digits) | constructor exception propagates |
+
+```csharp
+// nullable — null JSON produces null value
+CNPJ?    cnpj    = JsonSerializer.Deserialize<CNPJ?>("null");    // null
+LandLine? line   = JsonSerializer.Deserialize<LandLine?>("null"); // null
+
+// non-nullable — null JSON throws
+JsonSerializer.Deserialize<CPF>("null");  // JsonException
+```
+
+> **v10 breaking changes**
+> - `LandLineConverter` and `MobileConverter` previously serialized a JSON object
+>   (`{"Raw":"...","CountryCode":"...","AreaCode":"...","Number":"..."}`). They now
+>   serialize as a plain JSON string. Existing payloads produced with the old converters
+>   are **not** compatible with this version.
+> - `LandLineConverter` changed from `JsonConverter<LandLine?>` to `JsonConverter<LandLine>`.
+>   Property-level `[JsonConverter(typeof(LandLineConverter))]` annotations remain valid
+>   but are no longer needed.
+> - `CpfConverter` and `CnpjConverter` are new in v10.


### PR DESCRIPTION
## Summary

- **Upgrade to .NET 10** with modern C# idioms: `stackalloc`, `GeneratedRegex`, `Span<T>`, DoS input caps
- **Alphanumeric CNPJ** support per IN RFB nº 2.229/2024 (effective July 2026) — new check-digit algorithm, updated `ToString()` mask
- **CpfConverter and CnpjConverter** added — without these, `System.Text.Json` serialized CPF/CNPJ as `{Number, CheckNumber}` objects and could not reconstruct them on deserialization
- **PAN protection** — `CardNumber.Number` public property removed to prevent accidental leakage via logs, default serialization, or reflection
- **Complete JSON serialization test coverage** — all five converters (Mobile, LandLine, CardNumber, CPF, CNPJ) now have serialization, deserialization, round-trip (including `PropertyNameCaseInsensitive = true`), and null-token tests
- **Full test suite rewrite** — standardized coverage across all value objects; 256 tests passing

## Breaking changes (v10)

- `CNPJ`: `ToString()` uses alphanumeric mask for all formats; lowercase letters throw; internal helper methods removed from public API; `[Serializable]` removed
- `CPF`: internal helper methods (`IsNumeric`, `IsElevenLength`, `IsOutOfRange`, `GetNumberFrom`, `GetCheckNumberFrom`) removed from public API; `[Serializable]` removed
- `CardNumber`: `Number` property removed from public API
- `LandLine` / `Mobile`: `ToString()` format changed; some public methods removed
- JSON converters: payload format changed from JSON object to plain JSON string

## Test plan

- [x] All 256 tests passing (`dotnet test`)
- [x] Serialization as plain JSON string verified for all converters
- [x] Deserialization from plain JSON string verified for all converters
- [x] Round-trip with `PropertyNameCaseInsensitive = true` for CPF + CNPJ
- [x] Null token handling verified for all converters

🤖 Generated with [Claude Code](https://claude.com/claude-code)