### PR TITLE
feat: add CNH value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - `CEP` value object: Brazilian postal code (Correios), 8-digit numeric, mask `XXXXX-XXX`. Follows the same `readonly struct` + `[JsonConverter(typeof(CepConverter))]` pattern as all other types in the library.
+- `CNH` value object: Brazilian driver's license number (Carteira Nacional de Habilitação), 11-digit numeric with two weighted check digits per the SENATRAN algorithm (Resolução CONTRAN nº 541/2015). No standard display mask — stored and serialized as plain digits.
 
 ---
 

--- a/Person.Model.ValueObjects/CNH.cs
+++ b/Person.Model.ValueObjects/CNH.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Text.Json.Serialization;
+using Person.Model.ValueObjects.Json;
+
+namespace Person.Model.ValueObjects
+{
+    /// <summary>
+    /// Immutable value object representing a Brazilian driver's license number
+    /// (CNH — Carteira Nacional de Habilitação).
+    /// Format: 11 numeric digits with two weighted check digits per the SENATRAN algorithm
+    /// (Resolução CONTRAN nº 541/2015). No standard display mask.
+    /// </summary>
+    [JsonConverter(typeof(CnhConverter))]
+    public readonly struct CNH : IEquatable<CNH>
+    {
+        private const int CnhLength = 11;
+        private const int MaxInputLength = 20;
+
+        private readonly string _raw;
+
+        /// <summary>
+        /// Constructs a CNH from an 11-digit numeric string.
+        /// Leading and trailing whitespace is stripped automatically.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the format is invalid (non-numeric or wrong length) or when the input
+        /// exceeds <c>MaxInputLength</c> (20) characters.
+        /// </exception>
+        /// <exception cref="InvalidCastException">When the check digits do not match.</exception>
+        public CNH(string value)
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value),
+                    "Não é possível criar uma CNH a partir de um valor nulo.");
+
+            if (value.Length > MaxInputLength)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"Comprimento máximo permitido é {MaxInputLength} caracteres.");
+
+            value = StripMask(value);
+
+            if (!Patterns.CnhFormat().IsMatch(value))
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"Formato inválido. Esperado: string numérica de {CnhLength} dígitos.");
+
+            if (!Internal.IsValid(value))
+                throw new InvalidCastException(
+                    "A cadeia de caracteres informada não corresponde a uma CNH válida.");
+
+            _raw = value;
+        }
+
+        /// <summary>Returns the CNH as a plain 11-digit string. CNH has no standard display mask.</summary>
+        public override string ToString() => _raw ?? string.Empty;
+
+        public static implicit operator string(CNH cnh) => cnh._raw;
+
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <see langword="null"/> is assigned via implicit conversion.
+        /// Use <see cref="Nullable{CNH}"/> to represent the absence of a value.
+        /// </exception>
+        public static implicit operator CNH(string value) => value is null
+            ? throw new InvalidOperationException("Para valores nulos utilize CNH?.")
+            : new(value);
+
+        public static implicit operator CNH?(string value)
+        {
+            if (value == null) return null;
+            return new CNH(value);
+        }
+
+        /// <summary>
+        /// Validates a string as a CNH without throwing.
+        /// Strips leading and trailing whitespace before validating.
+        /// Returns <see langword="false"/> for strings exceeding <c>MaxInputLength</c> characters.
+        /// </summary>
+        public static bool IsValid(string? value)
+        {
+            if (value is null) return false;
+            if (value.Length > MaxInputLength) return false;
+            value = StripMask(value);
+            return Patterns.CnhFormat().IsMatch(value) && Internal.IsValid(value);
+        }
+
+        /// <summary>
+        /// Strips leading and trailing whitespace. CNH has no standard formatting mask.
+        /// </summary>
+        public static string StripMask(string value) => value.Trim();
+
+        public bool Equals(CNH other) => _raw == other._raw;
+        public override bool Equals(object? obj) => obj is CNH other && Equals(other);
+        public override int GetHashCode() => _raw?.GetHashCode() ?? 0;
+        public static bool operator ==(CNH left, CNH right) => left.Equals(right);
+        public static bool operator !=(CNH left, CNH right) => !left.Equals(right);
+
+        private static class Internal
+        {
+            // SENATRAN two-pass algorithm: both digit sets use the 9 base digits.
+            private static ReadOnlySpan<byte> Weights1 => [9, 8, 7, 6, 5, 4, 3, 2, 1];
+            private static ReadOnlySpan<byte> Weights2 => [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+            private static bool AllSame(string s)
+            {
+                char first = s[0];
+                for (int i = 1; i < s.Length; i++)
+                    if (s[i] != first) return false;
+                return true;
+            }
+
+            public static bool IsValid(string cnh)
+            {
+                if (AllSame(cnh)) return false;
+
+                ReadOnlySpan<byte> w1 = Weights1;
+                int sum1 = 0;
+                for (int i = 0; i < w1.Length; i++)
+                    sum1 += (cnh[i] - '0') * w1[i];
+
+                int r1 = sum1 % 11;
+                bool flag = r1 >= 10;
+                int d10 = flag ? 0 : r1;
+
+                if ((cnh[CnhLength - 2] - '0') != d10) return false;
+
+                ReadOnlySpan<byte> w2 = Weights2;
+                int sum2 = 0;
+                for (int i = 0; i < w2.Length; i++)
+                    sum2 += (cnh[i] - '0') * w2[i];
+
+                int r2 = sum2 % 11;
+                int d11Base = r2 >= 10 ? 0 : r2;
+                // When the first digit overflowed (flag), subtract 1 from the second digit (wrapping 0 → 9).
+                int d11 = flag ? (d11Base == 0 ? 9 : d11Base - 1) : d11Base;
+
+                return (cnh[CnhLength - 1] - '0') == d11;
+            }
+        }
+    }
+}

--- a/Person.Model.ValueObjects/Json/CnhConverter.cs
+++ b/Person.Model.ValueObjects/Json/CnhConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Person.Model.ValueObjects.Json
+{
+    public class CnhConverter : JsonConverter<CNH>
+    {
+        public override bool HandleNull => true;
+
+        public override CNH Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                throw new JsonException("CNH cannot be null. Use CNH? for nullable.");
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for CNH, got {reader.TokenType}.");
+            return new(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, CNH value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) CNH.");
+            writer.WriteStringValue(raw);
+        }
+    }
+}

--- a/Person.Model.ValueObjects/Patterns.cs
+++ b/Person.Model.ValueObjects/Patterns.cs
@@ -13,6 +13,9 @@ namespace Person.Model.ValueObjects
         [GeneratedRegex(@"^[0-9]{11}$")]
         internal static partial Regex CpfFormat();
 
+        [GeneratedRegex(@"^[0-9]{11}$")]
+        internal static partial Regex CnhFormat();
+
         [GeneratedRegex(
             @"^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?([2-5][0-9]{3}[- ]?[0-9]{4})$",
             RegexOptions.NonBacktracking)]

--- a/Person.Model.ValueObjectsTests/CnhTests.cs
+++ b/Person.Model.ValueObjectsTests/CnhTests.cs
@@ -106,6 +106,7 @@ namespace Person.Model.ValueObjects.Tests
         }
 
         [Test]
+        [TestCase("84718735254")]  // wrong first check digit (should be 6)
         [TestCase("84718735261")]  // wrong second check digit (should be 4)
         [TestCase("12345678901")]  // wrong second check digit (should be 0)
         [TestCase("20000001100")]  // wrong second check digit (should be 7)
@@ -113,6 +114,7 @@ namespace Person.Model.ValueObjects.Tests
         [TestCase("1234567890")]   // too short
         [TestCase("123456789000")] // too long
         [TestCase("1234567890A")]  // non-numeric
+        [TestCase("847187352641234567891")] // exceeds MaxInputLength (21 chars)
         [TestCase("")]
         public void IsValidReturnsFalseForInvalidInputTest(string value)
         {
@@ -199,9 +201,10 @@ namespace Person.Model.ValueObjects.Tests
 
         [Test]
         [TestCase("")]
-        [TestCase("1234567890")]    // 10 digits
-        [TestCase("123456789000")]  // 12 digits
-        [TestCase("1234567890A")]   // non-numeric
+        [TestCase("1234567890")]                       // 10 digits
+        [TestCase("123456789000")]                     // 12 digits
+        [TestCase("1234567890A")]                      // non-numeric
+        [TestCase("847187352641234567891")]             // 21 chars — exceeds MaxInputLength
         public void InvalidFormatShouldThrowArgumentOutOfRangeTest(string value)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new CNH(value));
@@ -212,6 +215,7 @@ namespace Person.Model.ValueObjects.Tests
         // ------------------------------------------------------------------ //
 
         [Test]
+        [TestCase("84718735254")] // first check digit should be 6, got 5
         [TestCase("84718735261")] // second check digit should be 4
         [TestCase("12345678901")] // second check digit should be 0
         [TestCase("20000001100")] // second check digit should be 7 (flag case)

--- a/Person.Model.ValueObjectsTests/CnhTests.cs
+++ b/Person.Model.ValueObjectsTests/CnhTests.cs
@@ -1,0 +1,325 @@
+using NUnit.Framework;
+using Person.Model.ValueObjects;
+using Person.Model.ValueObjects.Json;
+using System;
+using System.Text.Json;
+
+namespace Person.Model.ValueObjects.Tests
+{
+    [TestFixture]
+    internal class CnhTests
+    {
+        // ------------------------------------------------------------------ //
+        // Construction                                                         //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("12345678900")]
+        [TestCase("20000001107")] // flag case: first digit overflows (r1 >= 10)
+        [TestCase("15705560294")]
+        public void ValidCnhConstructionTest(string raw)
+        {
+            var cnh = new CNH(raw);
+
+            Assert.That((string)cnh, Is.EqualTo(raw));
+        }
+
+        [Test]
+        [TestCase("  84718735264  ")]
+        [TestCase(" 12345678900")]
+        [TestCase("20000001107 ")]
+        public void WhitespacePaddedInputIsAcceptedTest(string padded)
+        {
+            var cnh = new CNH(padded);
+
+            Assert.That((string)cnh, Is.EqualTo(padded.Trim()));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Implicit conversion                                                  //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("12345678900")]
+        public void ImplicitConversionFromStringTest(string value)
+        {
+            CNH cnh = value;
+
+            Assert.That((string)cnh, Is.EqualTo(value));
+        }
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("20000001107")]
+        public void ImplicitConversionToStringTest(string value)
+        {
+            CNH cnh = new(value);
+            string result = cnh;
+
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        // ------------------------------------------------------------------ //
+        // ToString                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("12345678900")]
+        [TestCase("20000001107")]
+        [TestCase("15705560294")]
+        public void ToStringReturnsRawDigitsTest(string raw)
+        {
+            var cnh = new CNH(raw);
+
+            // CNH has no standard display mask — ToString returns the 11-digit string.
+            Assert.That(cnh.ToString(), Is.EqualTo(raw));
+        }
+
+        // ------------------------------------------------------------------ //
+        // StripMask                                                            //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("  84718735264  ", "84718735264")]
+        [TestCase(" 12345678900", "12345678900")]
+        [TestCase("20000001107", "20000001107")]
+        public void StripMaskRemovesWhitespaceTest(string input, string expected)
+        {
+            Assert.That(CNH.StripMask(input), Is.EqualTo(expected));
+        }
+
+        // ------------------------------------------------------------------ //
+        // IsValid                                                              //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("12345678900")]
+        [TestCase("20000001107")]
+        [TestCase("15705560294")]
+        public void IsValidReturnsTrueForValidInputTest(string value)
+        {
+            Assert.That(CNH.IsValid(value), Is.True);
+        }
+
+        [Test]
+        [TestCase("84718735261")]  // wrong second check digit (should be 4)
+        [TestCase("12345678901")]  // wrong second check digit (should be 0)
+        [TestCase("20000001100")]  // wrong second check digit (should be 7)
+        [TestCase("00000000000")]  // null sentinel — passes mod-11 but is never a real CNH
+        [TestCase("1234567890")]   // too short
+        [TestCase("123456789000")] // too long
+        [TestCase("1234567890A")]  // non-numeric
+        [TestCase("")]
+        public void IsValidReturnsFalseForInvalidInputTest(string value)
+        {
+            Assert.That(CNH.IsValid(value), Is.False);
+        }
+
+        [Test]
+        public void IsValidReturnsFalseForNullTest()
+        {
+            Assert.That(CNH.IsValid(null), Is.False);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Nullable                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void NullableCnhBehaviorTest()
+        {
+            CNH? cnh = "84718735264";
+
+            Assert.That(cnh.HasValue, Is.True);
+            Assert.That((string)cnh.Value, Is.EqualTo("84718735264"));
+
+            cnh = null;
+
+            Assert.That(cnh.HasValue, Is.False);
+        }
+
+        [Test]
+        public void NullableCnhValueThrowsWhenNullTest()
+        {
+            CNH? cnh = null;
+
+            Assert.Throws<InvalidOperationException>(() => { var _ = cnh.Value; });
+        }
+
+        // ------------------------------------------------------------------ //
+        // Equality                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735264")]
+        [TestCase("12345678900")]
+        public void EqualityBetweenTwoInstancesTest(string value)
+        {
+            CNH a = new(value);
+            CNH b = new(value);
+
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a == b, Is.True);
+            Assert.That(a != b, Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void InequalityBetweenDifferentCnhTest()
+        {
+            CNH a = new("84718735264");
+            CNH b = new("12345678900");
+
+            Assert.That(a != b, Is.True);
+        }
+
+        // ------------------------------------------------------------------ //
+        // ArgumentNullException                                                //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void NullConstructorArgShouldThrowArgumentNullTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CNH(null!));
+        }
+
+        [Test]
+        public void NullImplicitAssignmentShouldThrowInvalidOperationTest()
+        {
+            Assert.Throws<InvalidOperationException>(() => { CNH cnh = (string)null; });
+        }
+
+        // ------------------------------------------------------------------ //
+        // ArgumentOutOfRangeException                                         //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("")]
+        [TestCase("1234567890")]    // 10 digits
+        [TestCase("123456789000")]  // 12 digits
+        [TestCase("1234567890A")]   // non-numeric
+        public void InvalidFormatShouldThrowArgumentOutOfRangeTest(string value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CNH(value));
+        }
+
+        // ------------------------------------------------------------------ //
+        // InvalidCastException                                                 //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("84718735261")] // second check digit should be 4
+        [TestCase("12345678901")] // second check digit should be 0
+        [TestCase("20000001100")] // second check digit should be 7 (flag case)
+        public void InvalidCheckDigitShouldThrowInvalidCastTest(string value)
+        {
+            Assert.Throws<InvalidCastException>(() => new CNH(value));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Homogeneous sequences                                                //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("00000000000")] // passes mod-11 but is a known null sentinel in DETRAN systems
+        [TestCase("11111111111")]
+        [TestCase("22222222222")]
+        [TestCase("33333333333")]
+        [TestCase("44444444444")]
+        [TestCase("55555555555")]
+        [TestCase("66666666666")]
+        [TestCase("77777777777")]
+        [TestCase("88888888888")]
+        [TestCase("99999999999")]
+        public void HomogeneousSequenceShouldThrowInvalidCastTest(string value)
+        {
+            Assert.Throws<InvalidCastException>(() => new CNH(value));
+        }
+
+        // ------------------------------------------------------------------ //
+        // JSON                                                                 //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void CnhConverterSerializesAsPlainStringTest()
+        {
+            CNH cnh = new("84718735264");
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            var json = JsonSerializer.Serialize(cnh, options);
+            var doc  = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo("84718735264"));
+        }
+
+        [Test]
+        public void CnhConverterDeserializesFromPlainStringTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            var result = JsonSerializer.Deserialize<CNH>("\"84718735264\"", options);
+
+            Assert.That(result, Is.EqualTo(new CNH("84718735264")));
+        }
+
+        [Test]
+        public void CnhConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNH>("null", options));
+        }
+
+        [Test]
+        public void CnhConverterThrowsOnNonStringTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CNH>("84718735264", options));
+        }
+
+        [Test]
+        public void NullableCnhRoundTripTest()
+        {
+            CNH? original = new CNH("84718735264");
+            var options   = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            var json   = JsonSerializer.Serialize(original, options);
+            var result = JsonSerializer.Deserialize<CNH?>(json, options);
+
+            Assert.That(result, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void NullableCnhNullJsonProducesNullTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CnhConverter());
+
+            var result = JsonSerializer.Deserialize<CNH?>("null", options);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void CnhAutoConverterRoundTripTest()
+        {
+            var original = new { Cnh = new CNH("84718735264") };
+
+            var json   = JsonSerializer.Serialize(original);
+            var result = JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json);
+
+            Assert.That(result["Cnh"].GetValue<string>(), Is.EqualTo("84718735264"));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -328,9 +328,52 @@ CEP.StripMask("01310-100"); // 01310100
 
 ---
 
+## CNH
+
+*Carteira Nacional de Habilitação* — Brazilian driver's license number issued by SENATRAN/DETRAN.
+
+11 numeric digits with two weighted check digits per the SENATRAN algorithm
+(Resolução CONTRAN nº 541/2015). No standard display mask — the number is stored and
+displayed as a plain 11-digit string.
+
+### Creation
+
+```csharp
+var cnh = new CNH("84718735264");
+
+CNH cnh = "84718735264";  // implicit operator
+CNH? cnh = null;          // nullable
+```
+
+| Exception | Condition |
+|---|---|
+| `ArgumentNullException` | `null` passed to constructor |
+| `InvalidOperationException` | `null` assigned via implicit operator — use `CNH?` |
+| `ArgumentOutOfRangeException` | non-numeric or wrong length |
+| `InvalidCastException` | check digits do not match |
+
+### Properties
+
+```csharp
+CNH cnh = "84718735264";
+
+Console.WriteLine((string)cnh);    // 84718735264
+Console.WriteLine(cnh.ToString()); // 84718735264
+```
+
+### Static helpers
+
+```csharp
+CNH.IsValid("84718735264"); // true
+CNH.IsValid("84718735261"); // false (wrong check digit)
+CNH.IsValid(null);          // false
+```
+
+---
+
 ## JSON converters
 
-All five value objects carry a `[JsonConverter]` attribute on the struct itself.
+All seven value objects carry a `[JsonConverter]` attribute on the struct itself.
 `System.Text.Json` discovers the converter automatically — no property annotation
 or `options.Converters.Add()` call is needed.
 
@@ -342,6 +385,7 @@ or `options.Converters.Add()` call is needed.
 | `LandLine` | `LandLineConverter` | `"555136352520"` |
 | `CardNumber` | `CardNumberConverter` | `"4929622041254286"` |
 | `CEP` | `CepConverter` | `"01310100"` |
+| `CNH` | `CnhConverter` | `"84718735264"` |
 
 All converters serialize as a **plain JSON string** — the canonical digit form, never the
 formatted mask (e.g. `123.456.789-09`).
@@ -349,11 +393,13 @@ formatted mask (e.g. `123.456.789-09`).
 ```csharp
 public class Subscriber
 {
-    public CPF      Cpf      { get; set; }
-    public CNPJ?    Cnpj     { get; set; }
-    public Mobile   Mobile   { get; set; }
-    public LandLine? LandLine { get; set; }
+    public CPF        Cpf        { get; set; }
+    public CNPJ?      Cnpj       { get; set; }
+    public Mobile     Mobile     { get; set; }
+    public LandLine?  LandLine   { get; set; }
     public CardNumber CardNumber { get; set; }
+    public CEP?       Cep        { get; set; }
+    public CNH?       Cnh        { get; set; }
 }
 
 // just works — no [JsonConverter] annotations required

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ CEP.StripMask("01310-100"); // 01310100
 
 11 numeric digits with two weighted check digits per the SENATRAN algorithm
 (Resolução CONTRAN nº 541/2015). No standard display mask — the number is stored and
-displayed as a plain 11-digit string.
+displayed as a plain 11-digit string. Leading and trailing whitespace is stripped automatically.
 
 ### Creation
 
@@ -367,6 +367,8 @@ Console.WriteLine(cnh.ToString()); // 84718735264
 CNH.IsValid("84718735264"); // true
 CNH.IsValid("84718735261"); // false (wrong check digit)
 CNH.IsValid(null);          // false
+
+CNH.StripMask("  84718735264  "); // 84718735264
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `CNH` value object: Brazilian driver's license number (Carteira Nacional de Habilitação), 11-digit numeric with two weighted check digits per the SENATRAN algorithm (Resolução CONTRAN nº 541/2015)
- `CnhConverter`: JSON serialization as plain digit string, consistent with all other converters in the project
- AllSame guard rejects homogeneous sequences (e.g. `"00000000000"`) used as null sentinels in DETRAN systems
- No standard display mask — `ToString()` returns the raw 11-digit string
- 379 tests, 0 failures

Closes #7

## Algorithm

Two-pass weighted check digit (SENATRAN):

| Pass | Weights | Result |
|---|---|---|
| 1st digit | `[9,8,7,6,5,4,3,2,1]` applied to digits 0–8 | `r1 % 11`; if `r1 >= 10` → digit is 0, flag set |
| 2nd digit | `[1,2,3,4,5,6,7,8,9]` applied to digits 0–8 | `r2 % 11`; if flag: subtract 1 (wrapping 0 → 9) |

## Test plan

- [x] Valid construction (4 cases including the flag case where 1st digit = 0)
- [x] Whitespace-padded input accepted
- [x] Implicit string conversions (both directions)
- [x] `ToString()` returns raw digits (no mask)
- [x] `StripMask` trims whitespace, identity case covered
- [x] `IsValid` true/false/null
- [x] Wrong 1st check digit → `InvalidCastException`
- [x] Wrong 2nd check digit → `InvalidCastException` (including flag case)
- [x] All 10 homogeneous sequences → `InvalidCastException`
- [x] Input exceeding `MaxInputLength` → `ArgumentOutOfRangeException`
- [x] Nullable behavior (`CNH?`)
- [x] JSON: serialize, deserialize, null token, non-string token, nullable round-trip, auto-converter

🤖 Generated with [Claude Code](https://claude.com/claude-code)