### PR TITLE
feat: add Email value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `CEP` value object: Brazilian postal code (Correios), 8-digit numeric, mask `XXXXX-XXX`. Follows the same `readonly struct` + `[JsonConverter(typeof(CepConverter))]` pattern as all other types in the library.
 - `PIS` value object: Brazilian worker identification number (also known as NIS / PASEP), 11-digit numeric with a weighted check digit (mod 11, weights `3,2,9,8,7,6,5,4,3,2`), mask `XXX.XXXXX.XX-X`.
+- `Email` value object: email address validated against a practical subset of RFC 5321/5322. Normalized to lowercase on construction. Exposes `Local` and `Domain` properties.
 
 ---
 

--- a/Person.Model.ValueObjects/Email.cs
+++ b/Person.Model.ValueObjects/Email.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Text.Json.Serialization;
+using Person.Model.ValueObjects.Json;
+
+namespace Person.Model.ValueObjects
+{
+    /// <summary>
+    /// Immutable value object representing an email address.
+    /// Validated against a practical subset of RFC 5321/5322:
+    /// local part up to 64 characters, total up to 254 characters, standard domain format.
+    /// Normalized to lowercase on construction. Leading and trailing whitespace is stripped.
+    /// </summary>
+    [JsonConverter(typeof(EmailConverter))]
+    public readonly struct Email : IEquatable<Email>
+    {
+        private const int MaxLength = 254;       // RFC 5321
+        private const int MaxLocalLength = 64;   // RFC 5321
+        private const int MaxInputLength = 320;  // pre-trim DoS guard
+
+        private readonly string _raw;            // normalized: trimmed, lowercased
+
+        /// <summary>
+        /// Constructs an Email from a string.
+        /// Leading/trailing whitespace is stripped and the address is normalized to lowercase.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the address exceeds <c>MaxInputLength</c> before trimming, when the normalized
+        /// address exceeds 254 characters (RFC 5321), when the local part exceeds 64 characters,
+        /// or when the format is invalid (structure, consecutive dots, leading/trailing dots).
+        /// </exception>
+        public Email(string value)
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value),
+                    "Não é possível criar um Email a partir de um valor nulo.");
+
+            if (value.Length > MaxInputLength)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"Comprimento máximo de entrada é {MaxInputLength} caracteres.");
+
+            value = value.Trim().ToLowerInvariant();
+
+            if (value.Length == 0 || value.Length > MaxLength)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"O endereço de e-mail deve ter entre 1 e {MaxLength} caracteres.");
+
+            if (!Patterns.EmailFormat().IsMatch(value))
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    "Formato de e-mail inválido.");
+
+            var atIdx = value.IndexOf('@');
+
+            if (atIdx > MaxLocalLength)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"A parte local (antes do @) deve ter no máximo {MaxLocalLength} caracteres.");
+
+            var local = value[..atIdx];
+
+            if (local[0] == '.' || local[^1] == '.' || local.Contains(".."))
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    "A parte local não pode começar ou terminar com ponto, nem conter pontos consecutivos.");
+
+            _raw = value;
+        }
+
+        /// <summary>The part of the address before the <c>@</c> sign.</summary>
+        public string Local => _raw is null ? string.Empty : _raw[.._raw.IndexOf('@')];
+
+        /// <summary>The part of the address after the <c>@</c> sign.</summary>
+        public string Domain => _raw is null ? string.Empty : _raw[(_raw.IndexOf('@') + 1)..];
+
+        /// <summary>Returns the email address in normalized form (lowercase).</summary>
+        public override string ToString() => _raw ?? string.Empty;
+
+        public static implicit operator string(Email email) => email._raw;
+
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <see langword="null"/> is assigned via implicit conversion.
+        /// Use <see cref="Nullable{Email}"/> to represent the absence of a value.
+        /// </exception>
+        public static implicit operator Email(string value) => value is null
+            ? throw new InvalidOperationException("Para valores nulos utilize Email?.")
+            : new(value);
+
+        public static implicit operator Email?(string value)
+        {
+            if (value == null) return null;
+            return new Email(value);
+        }
+
+        /// <summary>
+        /// Validates a string as an email address without throwing.
+        /// Applies the same normalization (trim + lowercase) before validating.
+        /// Returns <see langword="false"/> for strings exceeding <c>MaxInputLength</c> characters.
+        /// </summary>
+        public static bool IsValid(string? value)
+        {
+            if (value is null) return false;
+            if (value.Length > MaxInputLength) return false;
+            value = value.Trim().ToLowerInvariant();
+            if (value.Length == 0 || value.Length > MaxLength) return false;
+            if (!Patterns.EmailFormat().IsMatch(value)) return false;
+            var atIdx = value.IndexOf('@');
+            if (atIdx > MaxLocalLength) return false;
+            var local = value[..atIdx];
+            return local[0] != '.' && local[^1] != '.' && !local.Contains("..");
+        }
+
+        public bool Equals(Email other) => _raw == other._raw;
+        public override bool Equals(object? obj) => obj is Email other && Equals(other);
+        public override int GetHashCode() => _raw?.GetHashCode() ?? 0;
+        public static bool operator ==(Email left, Email right) => left.Equals(right);
+        public static bool operator !=(Email left, Email right) => !left.Equals(right);
+    }
+}

--- a/Person.Model.ValueObjects/Email.cs
+++ b/Person.Model.ValueObjects/Email.cs
@@ -73,7 +73,7 @@ namespace Person.Model.ValueObjects
         /// <summary>Returns the email address in normalized form (lowercase).</summary>
         public override string ToString() => _raw ?? string.Empty;
 
-        public static implicit operator string(Email email) => email._raw;
+        public static implicit operator string(Email email) => email._raw ?? string.Empty;
 
         /// <exception cref="InvalidOperationException">
         /// Thrown when <see langword="null"/> is assigned via implicit conversion.

--- a/Person.Model.ValueObjects/Json/EmailConverter.cs
+++ b/Person.Model.ValueObjects/Json/EmailConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Person.Model.ValueObjects.Json
+{
+    public class EmailConverter : JsonConverter<Email>
+    {
+        public override bool HandleNull => true;
+
+        public override Email Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                throw new JsonException("Email cannot be null. Use Email? for nullable.");
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a JSON string for Email, got {reader.TokenType}.");
+            return new(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Email value, JsonSerializerOptions options)
+        {
+            var raw = (string)value;
+            if (raw is null)
+                throw new JsonException("Cannot serialize a default (uninitialized) Email.");
+            writer.WriteStringValue(raw);
+        }
+    }
+}

--- a/Person.Model.ValueObjects/Patterns.cs
+++ b/Person.Model.ValueObjects/Patterns.cs
@@ -16,6 +16,10 @@ namespace Person.Model.ValueObjects
         [GeneratedRegex(@"^[0-9]{11}$")]
         internal static partial Regex PisFormat();
 
+        // Practical RFC 5321/5322 subset (after lowercasing): local@domain, domain requires dot.
+        [GeneratedRegex(@"^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$")]
+        internal static partial Regex EmailFormat();
+
         [GeneratedRegex(
             @"^(\+?55 ?)? ?(\([1-9]{2}\)|[1-9]{2}) ?([2-5][0-9]{3}[- ]?[0-9]{4})$",
             RegexOptions.NonBacktracking)]

--- a/Person.Model.ValueObjects/Patterns.cs
+++ b/Person.Model.ValueObjects/Patterns.cs
@@ -17,7 +17,9 @@ namespace Person.Model.ValueObjects
         internal static partial Regex PisFormat();
 
         // Practical RFC 5321/5322 subset (after lowercasing): local@domain, domain requires dot.
-        [GeneratedRegex(@"^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$")]
+        [GeneratedRegex(
+            @"^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$",
+            RegexOptions.NonBacktracking)]
         internal static partial Regex EmailFormat();
 
         [GeneratedRegex(

--- a/Person.Model.ValueObjectsTests/EmailTests.cs
+++ b/Person.Model.ValueObjectsTests/EmailTests.cs
@@ -1,0 +1,392 @@
+using NUnit.Framework;
+using Person.Model.ValueObjects;
+using Person.Model.ValueObjects.Json;
+using System;
+using System.Text.Json;
+
+namespace Person.Model.ValueObjects.Tests
+{
+    [TestFixture]
+    internal class EmailTests
+    {
+        // ------------------------------------------------------------------ //
+        // Construction                                                         //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("user.name@example.com")]
+        [TestCase("user+tag@gmail.com")]
+        [TestCase("rafael@example.com.br")]
+        [TestCase("u@example.co")]
+        public void ValidEmailConstructionTest(string address)
+        {
+            var email = new Email(address);
+
+            Assert.That((string)email, Is.EqualTo(address));
+        }
+
+        [Test]
+        [TestCase("User@Example.COM",    "user@example.com")]
+        [TestCase("RAFAEL@EXAMPLE.COM",  "rafael@example.com")]
+        [TestCase("User.Name@Gmail.Com", "user.name@gmail.com")]
+        public void ConstructionNormalizesToLowercaseTest(string input, string expected)
+        {
+            var email = new Email(input);
+
+            Assert.That((string)email, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("  user@example.com  ", "user@example.com")]
+        [TestCase(" rafael@example.com",  "rafael@example.com")]
+        [TestCase("user@example.com ",    "user@example.com")]
+        public void ConstructionStripsWhitespaceTest(string input, string expected)
+        {
+            var email = new Email(input);
+
+            Assert.That((string)email, Is.EqualTo(expected));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Properties                                                           //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com",       "user",      "example.com")]
+        [TestCase("user.name@example.com",  "user.name", "example.com")]
+        [TestCase("user+tag@gmail.com",     "user+tag",  "gmail.com")]
+        [TestCase("rafael@example.com.br",  "rafael",    "example.com.br")]
+        public void LocalAndDomainPropertiesTest(string address, string expectedLocal, string expectedDomain)
+        {
+            var email = new Email(address);
+
+            Assert.That(email.Local,  Is.EqualTo(expectedLocal));
+            Assert.That(email.Domain, Is.EqualTo(expectedDomain));
+        }
+
+        [Test]
+        public void DefaultEmailLocalAndDomainReturnEmptyTest()
+        {
+            Email email = default;
+
+            Assert.That(email.Local,  Is.EqualTo(string.Empty));
+            Assert.That(email.Domain, Is.EqualTo(string.Empty));
+        }
+
+        // ------------------------------------------------------------------ //
+        // ToString                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("user.name@example.com")]
+        public void ToStringReturnsNormalizedAddressTest(string address)
+        {
+            var email = new Email(address);
+
+            Assert.That(email.ToString(), Is.EqualTo(address));
+        }
+
+        [Test]
+        public void DefaultEmailToStringReturnsEmptyTest()
+        {
+            Email email = default;
+
+            Assert.That(email.ToString(), Is.EqualTo(string.Empty));
+        }
+
+        // ------------------------------------------------------------------ //
+        // Implicit conversion                                                  //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("user+tag@gmail.com")]
+        public void ImplicitConversionFromStringTest(string value)
+        {
+            Email email = value;
+
+            Assert.That((string)email, Is.EqualTo(value));
+        }
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("rafael@example.com.br")]
+        public void ImplicitConversionToStringTest(string value)
+        {
+            Email email = new(value);
+            string result = email;
+
+            Assert.That(result, Is.EqualTo(value));
+        }
+
+        // ------------------------------------------------------------------ //
+        // IsValid                                                              //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("user.name@example.com")]
+        [TestCase("user+tag@gmail.com")]
+        [TestCase("rafael@example.com.br")]
+        [TestCase("User@Example.COM")]          // case-insensitive
+        [TestCase("  user@example.com  ")]      // whitespace stripped
+        [TestCase("u@example.co")]
+        public void IsValidReturnsTrueForValidInputTest(string value)
+        {
+            Assert.That(Email.IsValid(value), Is.True);
+        }
+
+        [Test]
+        [TestCase("")]                          // empty
+        [TestCase("notanemail")]                // no @
+        [TestCase("@example.com")]              // empty local
+        [TestCase("user@")]                     // empty domain
+        [TestCase("user@example")]              // no dot in domain
+        [TestCase("user@@example.com")]         // multiple @
+        [TestCase(".user@example.com")]         // local starts with dot
+        [TestCase("user.@example.com")]         // local ends with dot
+        [TestCase("user..name@example.com")]    // consecutive dots in local
+        [TestCase("user@-example.com")]         // domain label starts with hyphen
+        [TestCase("user@example-.com")]         // domain label ends with hyphen
+        [TestCase("user@example..com")]         // consecutive dots in domain
+        public void IsValidReturnsFalseForInvalidInputTest(string value)
+        {
+            Assert.That(Email.IsValid(value), Is.False);
+        }
+
+        [Test]
+        public void IsValidReturnsFalseForNullTest()
+        {
+            Assert.That(Email.IsValid(null), Is.False);
+        }
+
+        [Test]
+        public void IsValidReturnsFalseWhenExceedsMaxLengthTest()
+        {
+            // 260 chars — exceeds RFC 5321 limit of 254
+            // 64 (local) + 1 (@) + 63.63.63.com (195) = 260
+            var local  = new string('a', 64);
+            var domain = new string('b', 63) + "." + new string('c', 63) + "." + new string('d', 63) + ".com";
+            var address = $"{local}@{domain}";
+            Assert.That(address.Length, Is.GreaterThan(254));
+            Assert.That(Email.IsValid(address), Is.False);
+        }
+
+        [Test]
+        public void IsValidReturnsFalseWhenLocalExceedsMaxLengthTest()
+        {
+            // local part of 65 chars — exceeds RFC 5321 limit of 64
+            var address = new string('a', 65) + "@example.com";
+            Assert.That(Email.IsValid(address), Is.False);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Nullable                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void NullableEmailBehaviorTest()
+        {
+            Email? email = "user@example.com";
+
+            Assert.That(email.HasValue, Is.True);
+            Assert.That((string)email.Value, Is.EqualTo("user@example.com"));
+
+            email = null;
+
+            Assert.That(email.HasValue, Is.False);
+        }
+
+        [Test]
+        public void NullableEmailValueThrowsWhenNullTest()
+        {
+            Email? email = null;
+
+            Assert.Throws<InvalidOperationException>(() => { var _ = email.Value; });
+        }
+
+        // ------------------------------------------------------------------ //
+        // Equality                                                             //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("user@example.com")]
+        [TestCase("rafael@example.com.br")]
+        public void EqualityBetweenTwoInstancesTest(string value)
+        {
+            Email a = new(value);
+            Email b = new(value);
+
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a == b, Is.True);
+            Assert.That(a != b, Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void InequalityBetweenDifferentEmailsTest()
+        {
+            Email a = new("user@example.com");
+            Email b = new("other@example.com");
+
+            Assert.That(a != b, Is.True);
+        }
+
+        [Test]
+        public void CaseDifferenceProducesEqualInstancesTest()
+        {
+            Email fromLower = new("user@example.com");
+            Email fromMixed = new("User@Example.COM");
+
+            Assert.That(fromLower, Is.EqualTo(fromMixed));
+            Assert.That(fromLower.GetHashCode(), Is.EqualTo(fromMixed.GetHashCode()));
+        }
+
+        // ------------------------------------------------------------------ //
+        // ArgumentNullException                                                //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void NullConstructorArgShouldThrowArgumentNullTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Email(null!));
+        }
+
+        [Test]
+        public void NullImplicitAssignmentShouldThrowInvalidOperationTest()
+        {
+            Assert.Throws<InvalidOperationException>(() => { Email email = (string)null; });
+        }
+
+        // ------------------------------------------------------------------ //
+        // ArgumentOutOfRangeException                                         //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        [TestCase("")]
+        [TestCase("notanemail")]
+        [TestCase("@example.com")]
+        [TestCase("user@")]
+        [TestCase("user@example")]
+        [TestCase("user@@example.com")]
+        [TestCase(".user@example.com")]
+        [TestCase("user.@example.com")]
+        [TestCase("user..name@example.com")]
+        public void InvalidFormatShouldThrowArgumentOutOfRangeTest(string value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Email(value));
+        }
+
+        [Test]
+        public void LocalPartExceedingMaxLengthShouldThrowArgumentOutOfRangeTest()
+        {
+            var address = new string('a', 65) + "@example.com";
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Email(address));
+        }
+
+        [Test]
+        public void TotalLengthExceedingMaxShouldThrowArgumentOutOfRangeTest()
+        {
+            var local  = new string('a', 64);
+            var domain = new string('b', 63) + "." + new string('c', 63) + "." + new string('d', 63) + ".com";
+            var address = $"{local}@{domain}";
+            Assert.That(address.Length, Is.GreaterThan(254));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Email(address));
+        }
+
+        // ------------------------------------------------------------------ //
+        // JSON                                                                 //
+        // ------------------------------------------------------------------ //
+
+        [Test]
+        public void EmailConverterSerializesAsPlainStringTest()
+        {
+            Email email  = new("user@example.com");
+            var options  = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            var json = JsonSerializer.Serialize(email, options);
+            var doc  = JsonDocument.Parse(json);
+
+            Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.String));
+            Assert.That(doc.RootElement.GetString(), Is.EqualTo("user@example.com"));
+        }
+
+        [Test]
+        public void EmailConverterDeserializesFromPlainStringTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            var result = JsonSerializer.Deserialize<Email>("\"user@example.com\"", options);
+
+            Assert.That(result, Is.EqualTo(new Email("user@example.com")));
+        }
+
+        [Test]
+        public void EmailConverterNormalizesOnDeserializeTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            var result = JsonSerializer.Deserialize<Email>("\"User@Example.COM\"", options);
+
+            Assert.That(result, Is.EqualTo(new Email("user@example.com")));
+        }
+
+        [Test]
+        public void EmailConverterThrowsOnNullTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Email>("null", options));
+        }
+
+        [Test]
+        public void EmailConverterThrowsOnNonStringTokenTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Email>("42", options));
+        }
+
+        [Test]
+        public void NullableEmailRoundTripTest()
+        {
+            Email? original = new Email("user@example.com");
+            var options     = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            var json   = JsonSerializer.Serialize(original, options);
+            var result = JsonSerializer.Deserialize<Email?>(json, options);
+
+            Assert.That(result, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void NullableEmailNullJsonProducesNullTest()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EmailConverter());
+
+            var result = JsonSerializer.Deserialize<Email?>("null", options);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void EmailAutoConverterRoundTripTest()
+        {
+            var original = new { Email = new Email("user@example.com") };
+
+            var json   = JsonSerializer.Serialize(original);
+            var result = JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json);
+
+            Assert.That(result["Email"].GetValue<string>(), Is.EqualTo("user@example.com"));
+        }
+    }
+}

--- a/Person.Model.ValueObjectsTests/EmailTests.cs
+++ b/Person.Model.ValueObjectsTests/EmailTests.cs
@@ -121,6 +121,15 @@ namespace Person.Model.ValueObjects.Tests
             Assert.That(result, Is.EqualTo(value));
         }
 
+        [Test]
+        public void DefaultEmailImplicitConversionToStringReturnsEmptyTest()
+        {
+            Email email = default;
+            string result = email;
+
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
         // ------------------------------------------------------------------ //
         // IsValid                                                              //
         // ------------------------------------------------------------------ //

--- a/README.md
+++ b/README.md
@@ -374,9 +374,58 @@ CEP.StripMask("01310-100"); // 01310100
 
 ---
 
+## Email
+
+Email address validated against a practical subset of RFC 5321/5322.
+Normalized to **lowercase** on construction — leading/trailing whitespace is stripped automatically.
+
+- Local part: up to 64 characters; cannot start or end with `.`; no consecutive dots.
+- Total address: up to 254 characters (RFC 5321).
+- Domain: must contain at least one dot; labels separated by `.` follow standard DNS rules.
+
+### Creation
+
+```csharp
+var email = new Email("user@example.com");
+var email = new Email("User@Example.COM"); // normalized to user@example.com
+
+Email email = "user@example.com"; // implicit operator
+Email? email = null;              // nullable
+```
+
+| Exception | Condition |
+|---|---|
+| `ArgumentNullException` | `null` passed to constructor |
+| `InvalidOperationException` | `null` assigned via implicit operator — use `Email?` |
+| `ArgumentOutOfRangeException` | invalid format, local part > 64 chars, or total > 254 chars |
+
+### Properties
+
+```csharp
+Email email = "user.name@example.com.br";
+
+Console.WriteLine((string)email);    // user.name@example.com.br
+Console.WriteLine(email.ToString()); // user.name@example.com.br
+Console.WriteLine(email.Local);      // user.name
+Console.WriteLine(email.Domain);     // example.com.br
+```
+
+### Static helpers
+
+```csharp
+Email.IsValid("user@example.com");      // true
+Email.IsValid("User@Example.COM");      // true  (case-insensitive)
+Email.IsValid("user@example");          // false (no dot in domain)
+Email.IsValid(".user@example.com");     // false (local starts with dot)
+Email.IsValid("user..name@example.com");// false (consecutive dots)
+Email.IsValid(null);                    // false
+```
+
+---
+
 ## JSON converters
 
-All seven value objects carry a `[JsonConverter]` attribute on the struct itself.
+All eight value objects carry a `[JsonConverter]` attribute on the struct itself.
 `System.Text.Json` discovers the converter automatically — no property annotation
 or `options.Converters.Add()` call is needed.
 
@@ -389,9 +438,10 @@ or `options.Converters.Add()` call is needed.
 | `CardNumber` | `CardNumberConverter` | `"4929622041254286"` |
 | `CEP` | `CepConverter` | `"01310100"` |
 | `PIS` | `PisConverter` | `"12345678919"` |
+| `Email` | `EmailConverter` | `"user@example.com"` |
 
-All converters serialize as a **plain JSON string** — the canonical digit form, never the
-formatted mask (e.g. `123.456.789-09`).
+All converters serialize as a **plain JSON string**. `Email` is always serialized in normalized
+(lowercase) form, regardless of the original casing used when the object was created.
 
 ```csharp
 public class Subscriber
@@ -403,6 +453,7 @@ public class Subscriber
     public CardNumber CardNumber { get; set; }
     public CEP?       Cep        { get; set; }
     public PIS?       Pis        { get; set; }
+    public Email?     Email      { get; set; }
 }
 
 // just works — no [JsonConverter] annotations required

--- a/README.md
+++ b/README.md
@@ -440,8 +440,9 @@ or `options.Converters.Add()` call is needed.
 | `PIS` | `PisConverter` | `"12345678919"` |
 | `Email` | `EmailConverter` | `"user@example.com"` |
 
-All converters serialize as a **plain JSON string**. `Email` is always serialized in normalized
-(lowercase) form, regardless of the original casing used when the object was created.
+All converters serialize as a **plain JSON string** — the canonical unformatted value, never a
+display mask (e.g. `PIS` as `"12345678919"`, not `"123.45678.91-9"`). `Email` is always serialized
+in normalized (lowercase) form, regardless of the original casing used when the object was created.
 
 ```csharp
 public class Subscriber


### PR DESCRIPTION
## Email value object

Adds an immutable `Email` value object validated against a practical subset of RFC 5321/5322.

### Behavior
- **Normalization:** trims whitespace and lowercases on construction; serialized always in normalized form.
- **Validation:** structural format via `EmailFormat()` regex, local part ≤ 64 chars, total ≤ 254 chars (RFC 5321), pre-trim DoS guard at 320 chars, and rejection of leading/trailing/consecutive dots in the local part.
- **API:** `IsValid` (non-throwing), implicit conversions to/from `string` (and `Email?`), value equality, and a `EmailConverter` for `System.Text.Json` mirroring the existing `PisConverter`.

### Review hardening (second commit)
- `implicit operator string` returns `string.Empty` for `default(Email)` instead of leaking `null` (NRE hazard), matching `ToString()`/`Local`/`Domain`.
- `EmailFormat()` regex marked `NonBacktracking` for guaranteed linear-time matching (ReDoS safety).
- README clarified: converters serialize the canonical unformatted value, never a display mask.
- Added a test covering `default(Email)` implicit string conversion.

### Tests
73 Email tests passing; full build clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
