### PR TITLE
chore: ignore .claude/ local state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# Claude Code local state
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so Claude Code's local state directory (transcripts, tool results, session data) stops showing up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
