### PR TITLE
docs: add Buy Me a Coffee support links

### DIFF
--- a/Person.Model.ValueObjects.Playground/Layout/MainLayout.razor
+++ b/Person.Model.ValueObjects.Playground/Layout/MainLayout.razor
@@ -22,6 +22,13 @@
     </MudAppBar>
     <MudMainContent>
         @Body
+        <footer class="d-flex justify-center align-center gap-2 py-6">
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                Open source (MIT)
+            </MudText>
+            <MudLink Href="https://buymeacoffee.com/rmcmenzc" Target="_blank"
+                     Typo="Typo.body2">☕ Buy me a coffee</MudLink>
+        </footer>
     </MudMainContent>
 </MudLayout>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/m4cm3nz/Person.Model.ValueObjects/actions/workflows/ci.yml/badge.svg)](https://github.com/m4cm3nz/Person.Model.ValueObjects/actions/workflows/ci.yml)
 [![Live demo](https://img.shields.io/badge/demo-playground-594ae2)](https://m4cm3nz.github.io/Person.Model.ValueObjects/)
+[![Buy me a coffee](https://img.shields.io/badge/buy%20me%20a%20coffee-support-ffdd00?logo=buymeacoffee&logoColor=000)](https://buymeacoffee.com/rmcmenzc)
 
 A .NET 10.0 collection of value objects for modelling Brazilian person domain properties.
 
@@ -562,3 +563,11 @@ The project lives in [`Person.Model.ValueObjects.Playground/`](Person.Model.Valu
 and references the library directly, so it always reflects real behaviour. It is published to GitHub
 Pages on every push to `master` by [`.github/workflows/pages.yml`](.github/workflows/pages.yml). To
 surface a new value object, add an entry to `DemoCatalog`.
+
+---
+
+## Support
+
+If this package saved you time, consider buying me a coffee ☕ — it helps keep the project maintained.
+
+**[☕ Buy me a coffee](https://buymeacoffee.com/rmcmenzc)**


### PR DESCRIPTION
Adds a discreet support/donation link in two places, as discussed.

## Changes
- **README**
  - A `Buy me a coffee` badge alongside the existing CI / live-demo badges at the top.
  - A short `## Support` section at the end with a coffee link.
- **Playground** (`MainLayout.razor`)
  - A subtle centered footer below the content: `Open source (MIT)` + `☕ Buy me a coffee`. No popups, nothing on the cards.

Link target: https://buymeacoffee.com/rmcmenzc

## Verification
- `dotnet build Person.Model.ValueObjects.Playground -c Release` → succeeds, 0 warnings / 0 errors.
- README badge and section render as standard Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)