### PR TITLE
docs: add "Why value objects?" intro to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 A .NET 10.0 collection of value objects for modelling Brazilian person domain properties.
 
+**Why value objects?** Instead of passing a `CPF` around as a `string`, you model it as a type that
+*cannot exist in an invalid state*: validation happens once, in the constructor, and every method that
+accepts a `Cpf` is guaranteed a valid one. You get rid of primitive obsession, scattered `if`-validation,
+and whole classes of bugs (a CEP assigned to a phone field simply won't compile).
+
+**The tradeoff:** a few more types and a little ceremony at the boundaries (parsing input, serializing
+output). This package absorbs most of that cost for you — implicit string conversions and JSON converters
+are built in.
+
 > 🔗 **[Try it live](https://m4cm3nz.github.io/Person.Model.ValueObjects/)** — a Blazor WebAssembly playground that runs the real package in your browser: validate, format, decompose and serialize every value object.
 
 ```csharp


### PR DESCRIPTION
Adds a short **Why value objects?** blurb near the top of the README (right after the description, before the *Try it live* callout), covering the benefits and the honest tradeoff of modelling domain primitives as value objects.

Plain-prose, non-jargony tone to stay approachable for newcomers.

## Verification
- Renders as standard Markdown; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)